### PR TITLE
Fix getCroSegsParseX: incorrect symmetries name

### DIFF
--- a/epsproc/IO.py
+++ b/epsproc/IO.py
@@ -1081,7 +1081,7 @@ def getCroSegsParseX(dumpSegs, symSegs, ekeList):
             sRep = {'ScatSym':'Total', 'ScatContSym':'Cont'}    # Dicitonary look-up for sym names
             try:
                 # dataList.append(daTmp.expand_dims({'Sym':symSegs[n]}))
-                symList = [symString[2].split()[1][1:3] for symString in symSegs[n]]
+                symList = [symString[2].split()[1].strip('"').strip('\'') for symString in symSegs[n]]
                 symRep = [stringRepMap(symString[2].split()[0],sRep) for symString in symSegs[n]]
 
             except IndexError as e:

--- a/epsproc/IO.py
+++ b/epsproc/IO.py
@@ -1081,7 +1081,7 @@ def getCroSegsParseX(dumpSegs, symSegs, ekeList):
             sRep = {'ScatSym':'Total', 'ScatContSym':'Cont'}    # Dicitonary look-up for sym names
             try:
                 # dataList.append(daTmp.expand_dims({'Sym':symSegs[n]}))
-                symList = [symString[2].split()[1].strip('"').strip('\'') for symString in symSegs[n]]
+                symList = [symString[2].split('#')[0].split()[1][1:-1] for symString in symSegs[n]]
                 symRep = [stringRepMap(symString[2].split()[0],sRep) for symString in symSegs[n]]
 
             except IndexError as e:


### PR DESCRIPTION
In `epsproc/IO.py` line 1084, `symSegs` is like
```
[[[0, 56, "ScatSym 'AP' # Scattering symmetry of total final state\n"], [0, 57, "ScatContSym 'AP' # Scattering symmetry of continuum electron\n"]], [[1, 268, "ScatSym 'APP' # Scattering symmetry of total final state\n"], [1, 269, "ScatContSym 'APP' # Scattering symmetry of continuum electron\n"]]]
```

Thus both `AP` and `APP` symmetry is parsed as `AP` in `symList` with `symString[2].split()[1][1:3]`

I tried to use `[1:-1]` instead of `[1:3]` slice to solve this issue, and replace the '#' first to avoid `'` followed by `#` with out space, e.g. `ScatSym 'APP'#Comment`